### PR TITLE
Definizione dei menu e delle icone social da config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,8 @@ languageCode = "it-it"
 title = "Lorem Ipsum"
 
 [Params]
-  ente = "Team Digitale"
+  ente = "Ente appartenenza/Owner"
+  enteLink = ""
   siteTitle = "Inserire qui il titolo"
   siteDescription = "Inserire qui la tag line"
 
@@ -20,3 +21,54 @@ title = "Lorem Ipsum"
     { label = "Note legali", url = "#" },
     { label = "Privacy policy", url = "#" }
   ]
+
+  [Params.socials]
+    [Params.socials.facebook]
+    name = "Facebook"
+    URL = ""
+    icon = "it-facebook"
+
+    [Params.socials.github]
+    name = "GitHub"
+    URL = ""
+    icon = "it-github"
+
+    [Params.socials.twitter]
+    name = "Twitter"
+    URL = ""
+    icon = "it-twitter"
+
+ [menu]
+    # slim-header
+     [[menu.main]]
+     name = "Forum"
+     URL = ""
+     weight = 2
+
+     [[menu.main]]
+     name = "Docs"
+     URL = ""
+     weight = 3
+
+    # header-nav
+    [[menu.navbar]]
+    name = "Link 1"
+    URL = ""
+    weight = 2
+
+    [[menu.navbar]]
+    name = "Link 2"
+    URL = "link2"
+    weight = 3
+
+    [[menu.navbar]]
+    name = "Link 4"
+    URL = ""
+    parent = "Dropdown"
+    weight = 4
+
+    [[menu.navbar]]
+    name = "Link 5"
+    URL = ""
+    parent = "Dropdown"
+    weight = 5

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -4,26 +4,49 @@
       <div class="row">
         <div class="col-12">
           <div class="it-header-slim-wrapper-content">
-            <a class="d-none d-lg-block navbar-brand" href="https://teamdigitale.governo.it/">{{ .Site.Params.ente }}</a>
-            <span class="nav-mobile">
+            <a class="d-none d-lg-block navbar-brand" href="{{ .Site.Params.enteLink }}">{{ .Site.Params.ente }}</a>
+            <div class="nav-mobile">
               <nav>
-                <a class="it-opener d-lg-none" data-toggle="collapse" href="#menu-principale" role="button" aria-expanded="false" aria-controls="menu1">
+                <a class="it-opener d-lg-none" data-toggle="collapse" href="#menu-principale" role="button" aria-expanded="false" aria-controls="menu-principale">
+                  <span>{{ .Site.Params.ente }}</span>
                   <svg class="icon">
-                    <use xlink:href="{{ .Site.BaseURL }}/svg/sprite.svg#it-list"></use>
+                    <use xlink:href="/svg/sprite.svg#it-expand"></use>
                   </svg>
                 </a>
                 <div class="link-list-wrapper collapse" id="menu-principale">
                   <ul class="link-list">
-                    <li><a href="https://pianotriennale-ict.italia.it">Piano Triennale</a></li>
-                    <li><a href="https://developers.italia.it/">Developers</a></li>
-                    <li><a href="https://designers.italia.it/">Designers</a></li>
-                    <li><a href="https://forum.italia.it/">Forum</a></li>
-                    <li><a href="https://docs.italia.it/">Docs</a></li>
-                    <li><a href="https://github.com/italia/">GitHub</a></li>
+                    {{ range .Site.Menus.main }}
+                    <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
+                    {{ end}}
                   </ul>
                 </div>
               </nav>
-            </span>
+            </div>
+            <div class="header-slim-right-zone">
+              <div class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown" aria-expanded="false">
+                  <span>ITA</span>
+                  <svg class="icon d-none d-lg-block">
+                    <use xlink:href="/svg/sprite.svg#it-expand"></use>
+                  </svg>
+                </a>
+                <div class="dropdown-menu">
+                  <div class="row">
+                    <div class="col-12">
+                      <div class="link-list-wrapper">
+                        <ul class="link-list">
+                          <li><a class="list-item" href="#"><span>ITA</span></a></li>
+                          <li><a class="list-item" href="#"><span>ENG</span></a></li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="it-access-top-wrapper">
+                <button class="btn btn-primary btn-sm" href="#" type="button">Accedi</button>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -38,15 +61,84 @@
               <div class="it-brand-wrapper">
                 <a href="#">
                   <svg class="icon">
-                    <use xlink:href="{{ .Site.BaseURL }}/svg/sprite.svg#it-code-circle"></use>
+                    <use xlink:href="/svg/sprite.svg#it-code-circle"></use>
                   </svg>
                   <div class="it-brand-text">
-                    <h2 class="no_toc">{{ .Site.Params.siteTitle }}</h2>
+                    <h2 class="no_toc">Lorem Ipsum</h2>
                     <h3 class="no_toc d-none d-md-block">{{ .Site.Params.siteDescription }}</h3>
                   </div>
                 </a>
               </div>
+              <div class="it-right-zone">
+                <div class="it-socials d-none d-md-flex">
+                  <span>Seguici su</span>
+                  <ul>
+                    {{ range .Site.Params.socials }}
+                        <li>
+                          <a href="{{ .URL }}" aria-label="{{ .Name }}" target="_blank">
+                            <svg class="icon">
+                              <use xlink:href="/svg/sprite.svg#{{ .icon }}"></use>
+                            </svg>
+                          </a>
+                        </li>
+                    {{ end }}
+                  </ul>
+                </div>
+                <div class="it-search-wrapper">
+                  <span class="d-none d-md-block">Cerca</span>
+                  <a class="search-link rounded-icon" href="#" aria-label="Cerca">
+                    <svg class="icon">
+                      <use xlink:href="/svg/sprite.svg#it-search"></use>
+                    </svg>
+                  </a>
+                </div>
+              </div>
             </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="it-header-navbar-wrapper">
+      <div class="container">
+        <div class="row">
+          <div class="col-12">
+
+            <nav class="navbar navbar-expand-lg has-megamenu">
+              <button class="custom-navbar-toggler" type="button" aria-controls="nav10" aria-expanded="false" aria-label="Toggle navigation" data-target="#nav10">
+                <svg class="icon">
+                  <use xlink:href="/svg/sprite.svg#it-burger"></use>
+                </svg>
+              </button>
+              <div class="navbar-collapsable" id="nav10">
+                <div class="overlay"></div>
+                <div class="close-div sr-only">
+                  <button class="btn close-menu" type="button"><span class="it-close"></span>close</button>
+                </div>
+                <div class="menu-wrapper">
+                  <ul class="navbar-nav">
+                     {{ range .Site.Menus.navbar }}
+                     {{ if .HasChildren }}
+                        <li class="nav-item dropdown">
+                          <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true"
+                            aria-expanded="false">
+                            {{ .Name }}
+                          </a>
+                          <div class="dropdown-menu" >
+                            {{ range .Children }}
+                            <a class="dropdown-item" href="{{ .URL | absURL }}">{{ .Name }}</a>
+                            {{ end }}
+                          </div>
+                        </li>
+                        {{ else }}
+                        <li class="nav-item">
+                          <a class="nav-link" href="{{ .URL | absURL }}">{{ .Name }}</a>
+                        </li>
+                     {{ end }}
+                     {{ end }}
+                  </ul>
+                </div>
+              </div>
+            </nav>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Descrizione
Aggiunge la possibilità di definire i due menu (slim-header e header-nav) e le icone social dell'header tramite il file `config.toml`. Al momento la header-nav non supporta il megamenu ma solo i menu semplici o di tipo dropdown.


## Checklist
- [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.