### PR TITLE
set bootstrap italia's __PUBLIC_PATH__ from gohugo's BaseURL

### DIFF
--- a/layouts/partials/site-scripts.html
+++ b/layouts/partials/site-scripts.html
@@ -1,4 +1,4 @@
-<script>window.__PUBLIC_PATH__ = '/fonts'</script>
+<script>window.__PUBLIC_PATH__ = '{{ .Site.BaseURL }}/fonts'</script>
 <script src="/js/bootstrap-italia.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
required if the site is installed in a subdir